### PR TITLE
Add usePrivateIp parameter for direct private IP connections

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,10 @@
       #                   targets behind a bastion/jump host. Passed as ssh -J flag.
       #   - buildOnTarget: (Optional) Whether to build NixOS configurations on the remote target.
       #                    Defaults to true. Set to false to build locally and copy the closure.
-      lib.mkRunner = { system, targetSystem ? "x86_64-linux", infraConfig, machineConfig, projectName ? "default", sshKeyPath ? null, sshConfigPath ? null, sshProxyJump ? null, buildOnTarget ? true }:
+      #   - usePrivateIp: (Optional) Whether to prefer private_ip from terraform output for
+      #                   target connections. Defaults to false. Useful when deploying to targets
+      #                   reachable via private network (e.g., VPN, VPC peering) without a proxy jump.
+      lib.mkRunner = { system, targetSystem ? "x86_64-linux", infraConfig, machineConfig, projectName ? "default", sshKeyPath ? null, sshConfigPath ? null, sshProxyJump ? null, buildOnTarget ? true, usePrivateIp ? false }:
         let
           pkgs = import nixpkgs {
             config.allowUnfree = true;
@@ -65,6 +68,11 @@
             then ''export SSH_PROXY_JUMP="${sshProxyJump}"''
             else "";
 
+          # Use private IP export line (only if usePrivateIp is true)
+          usePrivateIpExport = if usePrivateIp
+            then ''export USE_PRIVATE_IP="true"''
+            else "";
+
           # Build on target export line
           buildOnTargetExport = if buildOnTarget
             then ''export BUILD_ON_TARGET="true"''
@@ -86,6 +94,7 @@
             ${sshKeyExport}
             ${sshConfigExport}
             ${sshProxyJumpExport}
+            ${usePrivateIpExport}
             ${buildOnTargetExport}
 
             # Run the inframan binary with all arguments

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -53,6 +53,13 @@ func GetSSHProxyJump() string {
 	return os.Getenv("SSH_PROXY_JUMP")
 }
 
+// GetUsePrivateIP returns whether to prefer private_ip for target connections.
+// Defaults to false if not set.
+func GetUsePrivateIP() bool {
+	v := os.Getenv("USE_PRIVATE_IP")
+	return v == "true" || v == "1"
+}
+
 // GetBuildOnTarget returns whether colmena should build on the remote target.
 // Defaults to true if not set.
 func GetBuildOnTarget() bool {

--- a/internal/orchestrator/terraform.go
+++ b/internal/orchestrator/terraform.go
@@ -208,8 +208,8 @@ func (t *TerraformExecutor) GetTargetIP() (string, error) {
 		return "", fmt.Errorf("failed to parse terraform output: %w", err)
 	}
 
-	// When proxy jump is configured, prefer private_ip (target is behind bastion)
-	if GetSSHProxyJump() != "" {
+	// Prefer private_ip when explicitly requested or when proxy jump is configured
+	if GetUsePrivateIP() || GetSSHProxyJump() != "" {
 		if terraformOutput.PrivateIP.Value != "" {
 			return terraformOutput.PrivateIP.Value, nil
 		}
@@ -219,7 +219,7 @@ func (t *TerraformExecutor) GetTargetIP() (string, error) {
 		return terraformOutput.PublicIP.Value, nil
 	}
 
-	return "", fmt.Errorf("no IP found in terraform output (expected 'public_ip' or 'private_ip' with proxy jump configured)")
+	return "", fmt.Errorf("no IP found in terraform output (expected 'public_ip' or 'private_ip' with USE_PRIVATE_IP or proxy jump configured)")
 }
 
 // GetWorkDir returns the workdir path


### PR DESCRIPTION
## Summary
- Adds `usePrivateIp` parameter to `mkRunner` in flake.nix (defaults to `false`)
- When enabled, Colmena connects using `private_ip` from terraform output instead of `public_ip`
- Existing `sshProxyJump` behavior is unchanged — both options work independently

## Test plan
- [ ] Verify `usePrivateIp = true` causes deploy to use `private_ip` from terraform output
- [ ] Verify `sshProxyJump` still triggers private IP preference as before
- [ ] Verify default behavior (no flag set, no proxy jump) still uses `public_ip`