### PR TITLE
feat: add --auto-approve flag to infra and destroy commands

### DIFF
--- a/internal/commands/destroy.go
+++ b/internal/commands/destroy.go
@@ -9,6 +9,8 @@ import (
 
 // NewDestroyCommand creates the destroy command
 func NewDestroyCommand() *cobra.Command {
+	var autoApprove bool
+
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy infrastructure using Terraform",
@@ -18,7 +20,10 @@ func NewDestroyCommand() *cobra.Command {
 3. Passes through AWS credentials from environment
 
 This is the reverse of 'inframan infra' and will destroy all resources
-that were created during infrastructure provisioning.`,
+that were created during infrastructure provisioning.
+
+Use --auto-approve (-y) to skip the interactive approval prompt
+(typically required in CI environments).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Create terraform executor
 			terraformExec, err := orchestrator.NewTerraformExecutor()
@@ -33,7 +38,7 @@ that were created during infrastructure provisioning.`,
 
 			// Run terraform destroy
 			fmt.Println("Destroying infrastructure...")
-			if err := terraformExec.Destroy(); err != nil {
+			if err := terraformExec.Destroy(autoApprove); err != nil {
 				return fmt.Errorf("terraform destroy failed: %w", err)
 			}
 
@@ -41,6 +46,8 @@ that were created during infrastructure provisioning.`,
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&autoApprove, "auto-approve", "y", false, "Skip interactive approval of terraform destroy")
 
 	return cmd
 }

--- a/internal/commands/infra.go
+++ b/internal/commands/infra.go
@@ -10,6 +10,8 @@ import (
 
 // NewInfraCommand creates the infra command
 func NewInfraCommand() *cobra.Command {
+	var autoApprove bool
+
 	cmd := &cobra.Command{
 		Use:   "infra",
 		Short: "Apply infrastructure using Terranix and Terraform",
@@ -17,7 +19,10 @@ func NewInfraCommand() *cobra.Command {
 1. Reads the Terranix JSON config from INFRA_CONFIG_JSON env var
 2. Copies config to .inframan/terraform/config.tf.json
 3. Runs terraform init and terraform apply
-4. Passes through AWS credentials from environment`,
+4. Passes through AWS credentials from environment
+
+Use --auto-approve (-y) to skip the interactive approval prompt
+(typically required in CI environments).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get INFRA_CONFIG_JSON from environment
 			infraConfigJSON := os.Getenv("INFRA_CONFIG_JSON")
@@ -56,7 +61,7 @@ func NewInfraCommand() *cobra.Command {
 
 			// Run terraform apply
 			fmt.Println("Applying infrastructure...")
-			if err := terraformExec.Apply(); err != nil {
+			if err := terraformExec.Apply(autoApprove); err != nil {
 				return fmt.Errorf("terraform apply failed: %w", err)
 			}
 
@@ -64,6 +69,8 @@ func NewInfraCommand() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&autoApprove, "auto-approve", "y", false, "Skip interactive approval of terraform apply")
 
 	return cmd
 }

--- a/internal/orchestrator/terraform.go
+++ b/internal/orchestrator/terraform.go
@@ -103,9 +103,14 @@ func ensureInitInDir(terraformDir string) error {
 	return nil
 }
 
-// Apply runs terraform apply
-func (t *TerraformExecutor) Apply() error {
-	cmd := exec.Command("terraform", "apply")
+// Apply runs terraform apply. If autoApprove is true, passes -auto-approve
+// to skip the interactive confirmation (useful for CI).
+func (t *TerraformExecutor) Apply(autoApprove bool) error {
+	args := []string{"apply"}
+	if autoApprove {
+		args = append(args, "-auto-approve")
+	}
+	cmd := exec.Command("terraform", args...)
 	cmd.Dir = t.workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -152,9 +157,14 @@ func (t *TerraformExecutor) Import(address, id string) error {
 	return nil
 }
 
-// Destroy runs terraform destroy
-func (t *TerraformExecutor) Destroy() error {
-	cmd := exec.Command("terraform", "destroy")
+// Destroy runs terraform destroy. If autoApprove is true, passes -auto-approve
+// to skip the interactive confirmation (useful for CI).
+func (t *TerraformExecutor) Destroy(autoApprove bool) error {
+	args := []string{"destroy"}
+	if autoApprove {
+		args = append(args, "-auto-approve")
+	}
+	cmd := exec.Command("terraform", args...)
 	cmd.Dir = t.workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary
- Adds `--auto-approve` / `-y` flag to `inframan infra` and `inframan destroy` so they can run non-interactively in CI
- Threads the flag through `TerraformExecutor.Apply` / `Destroy`, which conditionally append `-auto-approve` to the underlying terraform invocation

## Test plan
- [ ] `inframan infra` (no flag) still prompts for approval interactively
- [ ] `inframan infra -y` applies without prompting
- [ ] `inframan destroy -y` destroys without prompting
- [ ] CI pipeline successfully runs `inframan infra -y`

🤖 Generated with [Claude Code](https://claude.com/claude-code)